### PR TITLE
feat: individual titles for blog posts and blog

### DIFF
--- a/apps/root.immich.app/routes/blog/+page.svelte
+++ b/apps/root.immich.app/routes/blog/+page.svelte
@@ -4,6 +4,14 @@
   import { DateTime } from 'luxon';
 </script>
 
+<svelte:head>
+  <title>Immich Blog</title>
+  <meta name="description" content="Latest updates, announcements, and stories from the Immich team." />
+  <meta property="og:title" content="Immich Blog" />
+  <meta property="og:description" content="Latest updates, announcements, and stories from the Immich team." />
+  <meta name="twitter:title" content="Immich Blog" />
+  <meta name="twitter:description" content="Latest updates, announcements, and stories from the Immich team." />
+</svelte:head>
 <Stack gap={8}>
   <section class="flex flex-col gap-2">
     <Heading size="title" tag="h1" fontWeight="bold">Blog</Heading>

--- a/src/lib/components/BlogPage.svelte
+++ b/src/lib/components/BlogPage.svelte
@@ -12,9 +12,17 @@
   };
 
   let { post, children, postScript }: Props = $props();
-  let { title, publishedAt, authors } = $derived(post);
+  let { title, publishedAt, authors, description } = $derived(post);
 </script>
 
+<svelte:head>
+  <title>{title} | Immich Blog</title>
+  <meta name="description" content={description} />
+  <meta property="og:title" content={`${title} | Immich Blog`} />
+  <meta property="og:description" content={description} />
+  <meta name="twitter:title" content={`${title} | Immich Blog`} />
+  <meta name="twitter:description" content={description} />
+</svelte:head>
 <Stack gap={6} class="text-lg">
   <ul class="flex gap-1 place-items-center text-muted">
     <li class="flex place-items-center">


### PR DESCRIPTION
When reading https://immich.app/blog/sync-v2 I noticed that all the blog posts do not have individual page titles, so I quickly fixed that to use the already present post.title and `... | Immich Blog`. While at it, I also changed the page title of the blog overview to include "Blog".