### PR TITLE
fix: normalize demo url

### DIFF
--- a/src/lib/api/services/playground-manager.svelte.ts
+++ b/src/lib/api/services/playground-manager.svelte.ts
@@ -180,7 +180,7 @@ class PlaygroundManager {
   }
 
   async connectToDemo(proxy?: boolean) {
-    const demoUrl = proxy ? '/api' : 'https://demo.immich.app/';
+    const demoUrl = this.normalize(proxy ? '/api' : 'https://demo.immich.app/');
     this.serverUrl = demoUrl;
     this.connect();
     const demoLogin = { email: 'demo@immich.app', password: 'demo' };


### PR DESCRIPTION
The login call was constructing it with a double slash in there and /api/ was missing.