### PR TITLE
feat: add Mimick to the list of Immich client apps

### DIFF
--- a/apps/awesome.immich.app/src/data/items.json
+++ b/apps/awesome.immich.app/src/data/items.json
@@ -38,6 +38,11 @@
         "title": "View-Only Web Interface",
         "description": "Display Immich photos publicly while allowing for the ability to filter and search for images.",
         "href": "https://github.com/JimmyeJones/Immich-View-Only-Web-Interface"
+      },
+      {
+        "title": "Mimick",
+        "description": "Unofficial GTK4 Immich client for Linux with persistent background sync.",
+        "href": "https://github.com/nicx17/mimick"
       }
     ]
   },


### PR DESCRIPTION
PR adds [Mimick](https://github.com/nicx17/mimick) to the Awesome Immich list under the "Client apps" category. 

Mimick is an unofficial GTK4 Immich client that I developed.

## Changes Made
- Added a new entry for Mimick in `apps/awesome.immich.app/src/data/items.json`.

## Validation
- [x] Verified JSON syntax is fully valid.
- [x] Verified the repository link is accessible.
