### PR TITLE
Add Darkroom Log - darkroom print session logger with Immich integration

### DIFF
--- a/apps/awesome.immich.app/src/data/items.json
+++ b/apps/awesome.immich.app/src/data/items.json
@@ -141,6 +141,11 @@
     "types": ["tool", "tools"],
     "projects": [
       {
+        "title": "Darkroom Log",
+        "description": "Self-hosted darkroom print session logger with Immich integration for analog photographers.",
+        "href": "https://github.com/jaapjan14/darkroom-log"
+      },
+      {
         "title": "Immich-Tiktok-Remover",
         "description": "Script to search for and remove TikTok videos from your Immich library.",
         "href": "https://github.com/mxc2/immich-tiktok-remover"


### PR DESCRIPTION
Adds Darkroom Log to the Tools section.

Darkroom Log is a self-hosted darkroom print session logger that integrates with Immich. Built for analog photographers who want to keep track of enlarger settings, exposure times, paper choices, and dodge/burn notes alongside their scanned negatives.

https://github.com/jaapjan14/darkroom-log