### PR TITLE
feat: add Immich Companion

### DIFF
--- a/apps/awesome.immich.app/src/data/items.json
+++ b/apps/awesome.immich.app/src/data/items.json
@@ -43,6 +43,11 @@
         "title": "Mimick",
         "description": "Unofficial GTK4 Immich client for Linux with persistent background sync.",
         "href": "https://github.com/nicx17/mimick"
+      },
+      {
+        "title": "Immich Companion",
+        "description": "Browser extension that adds right-click save to Immich, CLIP-powered search from the toolbar, optional new tab photo memories, and inline search results that show your photos alongside Google/DuckDuckGo results.",
+        "href": "https://github.com/bjoernch/immich-companion"
       }
     ]
   },


### PR DESCRIPTION
Add Immich Companion browser extension to Client apps

Adds Immich Companion, a community-built browser extension for self-hosted Immich using the Immich API. Features include:

- Right-click "Save image to Immich" -> saves directly to user's default album from any webpage
- CLIP-powered smart search from the toolbar popup -> search entire library by description ("red sunset", "kid on a bike")
- Optional new tab page replacement -> shows random photos plus "On this day" strip from past years
- Inline search results -> Immich cards appear above Google/DuckDuckGo results when the user's library contains matches

Placed under client-apps as a browser-based client interface, alongside ImmichFrame, Immich Kiosk, and the TV apps.