### PR TITLE
fix(confirm-modal): focus on open

### DIFF
--- a/packages/ui/src/lib/components/ConfirmModal/ConfirmModal.svelte
+++ b/packages/ui/src/lib/components/ConfirmModal/ConfirmModal.svelte
@@ -35,7 +35,7 @@
   };
 </script>
 
-<Modal {title} onClose={() => onClose(false)} {size} {icon}>
+<Modal {title} onClose={() => onClose(false)} {size} {icon} focusOnOpen>
   <ModalBody>
     {#if typeof prompt === 'string'}
       <p>{prompt}</p>


### PR DESCRIPTION
Adds `focusOnOpen` to all `ConfirmModal`. Fixes this issue where when deleting a face, the confirmation modal wouldn't get focus: https://github.com/immich-app/immich/issues/27386