### PR TITLE
feat: add lrimmich to CLI tools

### DIFF
--- a/apps/awesome.immich.app/src/data/items.json
+++ b/apps/awesome.immich.app/src/data/items.json
@@ -125,6 +125,11 @@
         "title": "immichpy",
         "description": "The stable, typed Python API layer for Immich automation and integrations.",
         "href": "https://github.com/timonrieger/immichpy"
+      },
+      {
+        "title": "lrimmich",
+        "description": "Sync albums and metadata from a Lightroom Classic catalog to Immich when both share the same photo folder via an external library.",
+        "href": "https://github.com/haavardnk/lrimmich"
       }
     ]
   },


### PR DESCRIPTION
Adds [lrimmich](https://github.com/haavardnk/lrimmich) to Awesome Immich under "Command-line tools".

lrimmich syncs albums and metadata from a Lightroom Classic catalog to Immich when both share the same photo folder via an external library.