### PR TITLE
chore: add borders to badge components

### DIFF
--- a/packages/ui/src/lib/components/Badge/Badge.svelte
+++ b/packages/ui/src/lib/components/Badge/Badge.svelte
@@ -37,12 +37,12 @@
     variants: {
       shape: styleVariants.shape,
       color: {
-        primary: 'bg-primary-100 text-primary-800',
-        secondary: 'bg-light-100 text-light-800',
-        success: 'bg-success-100 text-success-700',
-        info: 'bg-info-100 text-info-800',
-        warning: 'bg-warning-100 text-warning-800',
-        danger: 'bg-danger-100 text-danger-800',
+        primary: 'bg-primary-100 text-primary-800 border border-primary-200',
+        secondary: 'bg-light-100 text-light-800 border border-light-200',
+        success: 'bg-success-100 text-success-700 border border-success-200',
+        info: 'bg-info-100 text-info-800 border border-info-200',
+        warning: 'bg-warning-100 text-warning-800 border border-warning-200',
+        danger: 'bg-danger-100 text-danger-800 border border-danger-200',
       },
       textSize: styleVariants.textSize,
       paddingSize: {


### PR DESCRIPTION
<img width="840" height="1072" alt="image" src="https://github.com/user-attachments/assets/4fa3f628-7b80-49f9-a4a8-ff5650c8e40a" />
<img width="852" height="1057" alt="image" src="https://github.com/user-attachments/assets/f6a47b31-9c2f-498d-9d1c-a167df634c32" />
