### PR TITLE
fix: context menu click event

### DIFF
--- a/packages/ui/src/lib/components/ContextMenu/ContextMenuButton.svelte
+++ b/packages/ui/src/lib/components/ContextMenu/ContextMenuButton.svelte
@@ -19,6 +19,8 @@
   }: ContextMenuButtonProps = $props();
 
   const onclick = async (event: Event) => {
+    event.stopPropagation();
+    event.preventDefault();
     await menuManager.show({ target: event.currentTarget as HTMLElement, position, items, bottomItems });
   };
 </script>


### PR DESCRIPTION
Stop event propagation (when it's been handled)