### PR TITLE
fix(ui): document default toast timeout

### DIFF
--- a/packages/ui/src/lib/types.ts
+++ b/packages/ui/src/lib/types.ts
@@ -309,6 +309,7 @@ export type ToastShow = {
 
 export type ToastOptions = {
   id?: string;
+  /** default: 3000ms */
   timeout?: number;
   closable?: boolean;
 };


### PR DESCRIPTION
For a bit better developer experience. Is at risk of getting out of date with `toastManager`'s actual default, of course. Can maybe be documented on the toast manager or all variants of opening a toast instead but the property is the nicest.