### PR TITLE
feat(ui): add indicator to Icon

### DIFF
--- a/apps/ui.immich.app/src/routes/(docs)/components/icon/+page.svelte
+++ b/apps/ui.immich.app/src/routes/(docs)/components/icon/+page.svelte
@@ -5,6 +5,8 @@
   import basicExample from './BasicExample.svelte?raw';
   import ColorExample from './ColorExample.svelte';
   import colorExample from './ColorExample.svelte?raw';
+  import IndicatorExample from './IndicatorExample.svelte';
+  import indicatorExample from './IndicatorExample.svelte?raw';
   import OtherExample from './OtherExample.svelte';
   import otherExample from './OtherExample.svelte?raw';
   import SizeExample from './SizeExample.svelte';
@@ -17,6 +19,7 @@
       { title: 'Basic', code: basicExample, component: BasicExample },
       { title: 'Sizes', code: sizeExample, component: SizeExample },
       { title: 'Colors', code: colorExample, component: ColorExample },
+      { title: 'Indicator', code: indicatorExample, component: IndicatorExample },
       { title: 'Other', code: otherExample, component: OtherExample },
     ]}
   />

--- a/apps/ui.immich.app/src/routes/(docs)/components/icon/IndicatorExample.svelte
+++ b/apps/ui.immich.app/src/routes/(docs)/components/icon/IndicatorExample.svelte
@@ -1,27 +1,19 @@
 <script lang="ts">
-  import { Icon, Stack, Text, type Color } from '@immich/ui';
+  import ComponentColors from '$lib/components/ComponentColors.svelte';
+  import { Icon, Stack, Text } from '@immich/ui';
   import { mdiBell } from '@mdi/js';
 
   const icon = mdiBell;
   const size = '32';
-
-  type Item = { item: Color; label: string };
-
-  const colors: Item[] = [
-    { item: 'primary', label: 'Primary' },
-    { item: 'secondary', label: 'Secondary' },
-    { item: 'success', label: 'Success' },
-    { item: 'info', label: 'Info' },
-    { item: 'warning', label: 'Warning' },
-    { item: 'danger', label: 'Danger' },
-  ];
 </script>
 
 <Stack>
-  {#each colors as item (item.item)}
-    <div class="flex place-items-center gap-2">
-      <Icon {icon} {size} indicator={item.item} />
-      <Text>{item.label}</Text>
-    </div>
-  {/each}
+  <ComponentColors>
+    {#snippet child({ label, color })}
+      <div class="flex place-items-center gap-2">
+        <Icon {icon} {size} indicator={color} />
+        <Text>{label}</Text>
+      </div>
+    {/snippet}
+  </ComponentColors>
 </Stack>

--- a/apps/ui.immich.app/src/routes/(docs)/components/icon/IndicatorExample.svelte
+++ b/apps/ui.immich.app/src/routes/(docs)/components/icon/IndicatorExample.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { Icon, Stack, Text, type Color } from '@immich/ui';
+  import { mdiBell } from '@mdi/js';
+
+  const icon = mdiBell;
+  const size = '32';
+
+  type Item = { item: Color; label: string };
+
+  const colors: Item[] = [
+    { item: 'primary', label: 'Primary' },
+    { item: 'secondary', label: 'Secondary' },
+    { item: 'success', label: 'Success' },
+    { item: 'info', label: 'Info' },
+    { item: 'warning', label: 'Warning' },
+    { item: 'danger', label: 'Danger' },
+  ];
+</script>
+
+<Stack>
+  {#each colors as item (item.item)}
+    <div class="flex place-items-center gap-2">
+      <Icon {icon} {size} indicator={item.item} />
+      <Text>{item.label}</Text>
+    </div>
+  {/each}
+</Stack>

--- a/packages/ui/src/lib/components/Icon/Icon.svelte
+++ b/packages/ui/src/lib/components/Icon/Icon.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+  import { styleVariants } from '$lib/styles.js';
   import type { IconProps } from '$lib/types.js';
   import { cleanClass } from '$lib/utilities/internal.js';
   import type { HTMLAttributes } from 'svelte/elements';
+  import { tv } from 'tailwind-variants';
 
   const {
     size = '1em',
@@ -28,6 +30,12 @@
       return { x: Number(xEnd) - radius, y: Number(yStart) + radius, radius };
     }
   });
+
+  const indicatorStyles = tv({
+    variants: {
+      color: styleVariants.textColor,
+    },
+  });
 </script>
 
 <svg
@@ -48,7 +56,13 @@
   {/if}
   <path d={typeof icon === 'string' ? icon : icon.path} fill={color} />
   {#if indicatorColor && indicator}
-    <circle cx={indicator.x} cy={indicator.y} r={indicator.radius} fill="var(--immich-ui-{indicatorColor}-500"></circle>
+    <circle
+      cx={indicator.x}
+      cy={indicator.y}
+      r={indicator.radius}
+      fill="currentColor"
+      class={indicatorStyles({ color: indicatorColor })}
+    ></circle>
   {/if}
 </svg>
 

--- a/packages/ui/src/lib/components/Icon/Icon.svelte
+++ b/packages/ui/src/lib/components/Icon/Icon.svelte
@@ -7,6 +7,7 @@
     size = '1em',
     viewBox = '0 0 24 24',
     class: className = '',
+    indicator: indicatorColor,
     flipped = false,
     flopped = false,
     spin = false,
@@ -19,6 +20,14 @@
     description,
     ...restProps
   }: IconProps & HTMLAttributes<EventTarget> = $props();
+
+  const indicator = $derived.by(() => {
+    const [_, yStart, xEnd, yEnd] = viewBox.split(' ');
+    if (yStart && xEnd && yEnd) {
+      const radius = Math.min(Number(xEnd), Number(yEnd)) / 8;
+      return { x: Number(xEnd) - radius, y: Number(yStart) + radius, radius };
+    }
+  });
 </script>
 
 <svg
@@ -38,6 +47,9 @@
     <desc>{description}</desc>
   {/if}
   <path d={typeof icon === 'string' ? icon : icon.path} fill={color} />
+  {#if indicatorColor && indicator}
+    <circle cx={indicator.x} cy={indicator.y} r={indicator.radius} fill="var(--immich-ui-{indicatorColor}-500"></circle>
+  {/if}
 </svg>
 
 <style>

--- a/packages/ui/src/lib/components/IconButton/IconButton.svelte
+++ b/packages/ui/src/lib/components/IconButton/IconButton.svelte
@@ -7,6 +7,7 @@
     icon,
     flipped,
     flopped,
+    indicator,
     title,
     'aria-label': ariaLabel,
     color = 'primary',
@@ -17,5 +18,5 @@
 </script>
 
 <Button icon {color} {...buttonProps} title={buttonTitle} aria-label={ariaLabel}>
-  <Icon {icon} {flipped} {flopped} size="60%" aria-hidden />
+  <Icon {icon} {flipped} {flopped} {indicator} size="60%" aria-hidden />
 </Button>

--- a/packages/ui/src/lib/types.ts
+++ b/packages/ui/src/lib/types.ts
@@ -76,6 +76,7 @@ export type IconProps = {
   description?: string;
   size?: string;
   color?: Color | 'currentColor' | string;
+  indicator?: Color;
   flipped?: boolean;
   flopped?: boolean;
   spin?: boolean;
@@ -125,6 +126,7 @@ export type IconButtonProps = ButtonBase & {
   icon: IconLike;
   flipped?: boolean;
   flopped?: boolean;
+  indicator?: Color;
   'aria-label': string;
 } & ButtonOrAnchor;
 


### PR DESCRIPTION
A suggestion/proof of concept to add an indicator dot/circle to the Icon. Can be useful for a few things. Maybe it should be moved to the IconButton since it implies a possible action. Let me know what you think!

<img width="913" height="1058" alt="image" src="https://github.com/user-attachments/assets/8b23dbea-9a05-4624-89cc-7e90a8c4cedb" />
