### PR TITLE
fix(blog): typos

### DIFF
--- a/apps/root.immich.app/src/routes/blog/(posts)/2026-june-recap/+page.md
+++ b/apps/root.immich.app/src/routes/blog/(posts)/2026-june-recap/+page.md
@@ -49,7 +49,7 @@ Here is what the webhook trigger action item looks like in the action picker on 
 
 ![Selected webhook action ](https://static.immich.cloud/blog/af8e01bf-2d44-4042-b3de-5d5c463b7b52/749e388f5abf07e69b08094afa6c158b.webp)
 
-Once the "Trigger Webhook" action has been selected, you are able to configure it with a destination url, the HTTP request method (POST vs PUT), and an optional header to send with the request. It is quite common for webhooks to require authentication, and the header configuration allows the user to send one with each request.
+Once the "Trigger Webhook" action has been selected, you are able to configure it with a destination URL, the HTTP request method (POST vs PUT), and an optional header to send with the request. It is quite common for webhooks to require authentication, and the header configuration allows the user to send one with each request.
 
 Here is an example configuration:
 

--- a/apps/root.immich.app/src/routes/blog/(posts)/futo-two-years-later/+page.md
+++ b/apps/root.immich.app/src/routes/blog/(posts)/futo-two-years-later/+page.md
@@ -144,7 +144,7 @@ Being part of FUTO has given us a lot of support, especially in areas outside of
 
 ## Community concerns
 
-It's worth mentioning that in response to the original announcement, which was also posted in [Discord](http://discord.immich.app/), [Reddit](https://www.reddit.com/r/immich/comments/1chmywa/the_immich_core_team_goes_fulltime/), and [GitHub](https://github.com/immich-app/immich/discussions/9206), many of you wrote comments expressing additional concerns. Some of the common areas included doubts that:
+It's worth mentioning that in response to the original announcement, which was also posted in [Discord](https://discord.immich.app/), [Reddit](https://www.reddit.com/r/immich/comments/1chmywa/the_immich_core_team_goes_fulltime/), and [GitHub](https://github.com/immich-app/immich/discussions/9206), many of you wrote comments expressing additional concerns. Some of the common areas included doubts that:
 
 - The product would get worse
 - Immich would become a paid product

--- a/apps/root.immich.app/src/routes/blog/(posts)/v3-migration/+page.md
+++ b/apps/root.immich.app/src/routes/blog/(posts)/v3-migration/+page.md
@@ -188,7 +188,7 @@ Search endpoints have been updated with the following changes:
 
 #### `PATCH /shared-links/:id` / `updateSharedLink`
 
-- The `changeExpiryTime` property of `SharedLinkEditDto` has been removed (instead send `expiresAt` with a `null` value) 
+- The `changeExpiryTime` property of `SharedLinkEditDto` has been removed (instead send `expiresAt` with a `null` value)
 
 #### `PUT /system-config` / `updateConfig`
 

--- a/apps/root.immich.app/src/routes/blog/(recaps)/2025-october-recap/+page.md
+++ b/apps/root.immich.app/src/routes/blog/(recaps)/2025-october-recap/+page.md
@@ -39,9 +39,9 @@ We are blown away by the support from everyone around this milestone, especially
 
 Including the stable release, we had 3 releases this month (excluding patch releases).
 
-- [v2.2.0](https://github.com/immich-app/immich/releases/tag/v2.2.0) &mdash; Activity view (mobile), video seeking (mobile), duplicate management improvements (web), and **OCR**
-- [v2.1.0](https://github.com/immich-app/immich/releases/tag/v2.1.0) &mdash; Improved slideshow shuffle (web), upload to stack (web), album notifications (web)
-- [v2.0.0](https://github.com/immich-app/immich/releases/tag/v2.0.0) &mdash; Stable release
+- [v2.2.0](https://github.com/immich-app/immich/releases/tag/v2.2.0) — Activity view (mobile), video seeking (mobile), duplicate management improvements (web), and **OCR**
+- [v2.1.0](https://github.com/immich-app/immich/releases/tag/v2.1.0) — Improved slideshow shuffle (web), upload to stack (web), album notifications (web)
+- [v2.0.0](https://github.com/immich-app/immich/releases/tag/v2.0.0) — Stable release
 
 ## Immich on Hacker News
 
@@ -75,15 +75,15 @@ This month, we reached **83,000** stars on our [GitHub repository](https://githu
 
 If you want to follow along with us, you can see these metrics and more on <https://data.immich.app/>!
 
-## Developer update &mdash; from the labyrinth
+## Developer update — from the labyrinth
 
 _Our team members’ unfiltered thoughts on the good, the bad, and the frustration about the current tasks they are working on._
 
-**Alex** &mdash; Handling the initial iCloud backup is still a PITA, but seeing the crash rate of Android tick down makes me happy. However, I am still not satisfied with the current upload situation. OCR is actually very cool for playing “I Spy” with your kids. I will finally get to work on the workflow feature, which I’ve always wanted for a long time.
+**Alex** — Handling the initial iCloud backup is still a PITA, but seeing the crash rate of Android tick down makes me happy. However, I am still not satisfied with the current upload situation. OCR is actually very cool for playing “I Spy” with your kids. I will finally get to work on the workflow feature, which I’ve always wanted for a long time.
 
-**Jason** &mdash; What is a vite preprocessor? Well, it turns out that you can transform code from one format to another using [vite plugins](https://vite.dev/guide/api-plugin.html#transforming-custom-file-types). This month I wrote my own, in order make it possible to write blog posts in markdown, but render them using our own custom Svelte components.
+**Jason** — What is a vite preprocessor? Well, it turns out that you can transform code from one format to another using [vite plugins](https://vite.dev/guide/api-plugin.html#transforming-custom-file-types). This month I wrote my own, in order make it possible to write blog posts in markdown, but render them using our own custom Svelte components.
 
-**Zack** &mdash; In the run up to stable release, I thought I would be working on bug fixes and other coordination around the release. Alas no, after we decided to launch the [Immich Retro DVD](https://immich.store/products/immich-retro), it turns out worldwide fulfillment is still not a solved problem… so now I know far more than I ever wanted to about global fulfillment, tax laws, hooking all those systems together, and plenty more. At least it seems like people liked it 😅
+**Zack** — In the run up to stable release, I thought I would be working on bug fixes and other coordination around the release. Alas no, after we decided to launch the [Immich Retro DVD](https://immich.store/products/immich-retro), it turns out worldwide fulfillment is still not a solved problem… so now I know far more than I ever wanted to about global fulfillment, tax laws, hooking all those systems together, and plenty more. At least it seems like people liked it 😅
 
 ## Upcoming goals
 

--- a/apps/root.immich.app/src/routes/blog/(recaps)/2025-october-recap/+page.md
+++ b/apps/root.immich.app/src/routes/blog/(recaps)/2025-october-recap/+page.md
@@ -81,7 +81,7 @@ _Our team members’ unfiltered thoughts on the good, the bad, and the frustrati
 
 **Alex** — Handling the initial iCloud backup is still a PITA, but seeing the crash rate of Android tick down makes me happy. However, I am still not satisfied with the current upload situation. OCR is actually very cool for playing “I Spy” with your kids. I will finally get to work on the workflow feature, which I’ve always wanted for a long time.
 
-**Jason** — What is a vite preprocessor? Well, it turns out that you can transform code from one format to another using [vite plugins](https://vite.dev/guide/api-plugin.html#transforming-custom-file-types). This month I wrote my own, in order make it possible to write blog posts in markdown, but render them using our own custom Svelte components.
+**Jason** — What is a vite preprocessor? Well, it turns out that you can transform code from one format to another using [vite plugins](https://vite.dev/guide/api-plugin.html#transforming-custom-file-types). This month I wrote my own, in order to make it possible to write blog posts in markdown, but render them using our own custom Svelte components.
 
 **Zack** — In the run up to stable release, I thought I would be working on bug fixes and other coordination around the release. Alas no, after we decided to launch the [Immich Retro DVD](https://immich.store/products/immich-retro), it turns out worldwide fulfillment is still not a solved problem… so now I know far more than I ever wanted to about global fulfillment, tax laws, hooking all those systems together, and plenty more. At least it seems like people liked it 😅
 

--- a/apps/root.immich.app/src/routes/blog/(recaps)/2026-may-recap/+page.md
+++ b/apps/root.immich.app/src/routes/blog/(recaps)/2026-may-recap/+page.md
@@ -97,7 +97,7 @@ Actually, I just checked my commits to the main repository and it's almost exclu
 
 This month, my primary focus was on the sharing rework. After running against a rather significant wall, we've decided on a new design for people sharing and so far this seems to be promising. I am hoping to start properly implementing the first pieces of the rework in the next month, and finally leave the proof of concept phase.
 
-In addition to continued work on sharing, I also worked on refactorings as well as cleaning up some deprecated APIs. Furthermore, I made <https://version.immich.cloud,> the Immich server, and Immich web work with prereleases (you know, a release candidate kind of thing like `v3.0.0-rc.0`). We're planning to publish release candidates for v3 and any future major version. Since we haven't done something like that before, many components didn't support this properly, thus needing adapting and testing.
+In addition to continued work on sharing, I also worked on refactorings as well as cleaning up some deprecated APIs. Furthermore, I made [version.immich.cloud](https://version.immich.cloud/version), the Immich server, and Immich web work with prereleases (you know, a release candidate kind of thing like `v3.0.0-rc.0`). We're planning to publish release candidates for v3 and any future major version. Since we haven't done something like that before, many components didn't support this properly, thus needing adapting and testing.
 
 Lastly, I helped reviewing and providing feedback on some of those other huge features, especially workflows :)
 

--- a/apps/root.immich.app/src/routes/blog/(recaps)/2026-may-recap/+page.md
+++ b/apps/root.immich.app/src/routes/blog/(recaps)/2026-may-recap/+page.md
@@ -31,7 +31,7 @@ See the full chart on [data.immich.app](https://data.immich.app/)
 
 ## 10,000th Commit
 
-It is kind of crazy to see the 10,000th commit in the Immich repository. I remember seeing nodejs go over 10,000 commits back in 2014 when I started my career and thinking "now _that_ is a serious project". It's so awesome to be able to work on Immich everyday, and be apart of such an awesome community. Here's to the next 10,000 commits!
+It is kind of crazy to see the 10,000th commit in the Immich repository. I remember seeing nodejs go over 10,000 commits back in 2014 when I started my career and thinking "now _that_ is a serious project". It's so awesome to be able to work on Immich everyday, and be a part of such an awesome community. Here's to the next 10,000 commits!
 
 ## Recent uploads
 
@@ -57,7 +57,7 @@ Since the last update we have also added the "Browse templates" button. Template
 
 ### Editor
 
-The workflow editor has also had a few changes, and this is what it looks like now. It has both a visual and JSON view. Each workflow has a trigger, and then a list of steps. A step is made up of an filter or action and any associated configuration. The interface supports reordering steps via drag-and-drop, which is pretty nice. Lastly, a workflow also supports copying and downloading, so that you can easily share them with other users. At some point we would love to build out some type or marketplace or registry where users can browse existing templates.
+The workflow editor has also had a few changes, and this is what it looks like now. It has both a visual and JSON view. Each workflow has a trigger, and then a list of steps. A step is made up of a filter or action and any associated configuration. The interface supports reordering steps via drag-and-drop, which is pretty nice. Lastly, a workflow also supports copying and downloading, so that you can easily share them with other users. At some point we would love to build out some type or marketplace or registry where users can browse existing templates.
 
 ![The workflow editor show an example workflow ](https://static.immich.cloud/blog/84a0ba7d-ed36-4044-a20b-b0d7018b1d47/ebfd6445da664e2a3d83b54ae77fe573.webp)
 


### PR DESCRIPTION
### Description

Fix minor typos.

v3-migration
- trailing whitespace

2026-june-recap
- capitalize url -> URL

futo-two-years-later
- https for Discord link

2026-may
- 2 typos
- link to version.immich.cloud

2025-october-recap
- several `&mdash;` displayed verbatim on web
- missing "to"

---

### Out of scope

Tables in v3-migration post:
Unexpected line breaks in the middle of words: "owne d", "u ser", "be en", "lensMo del". Checked in Firefox 153.0b3 and Chromium 147.0.7727.116.
Seemingly due to `break-all` class in TableCell.svelte.
<details><summary>Screenshot</summary>

<img width="800" height="610" alt="image" src="https://github.com/user-attachments/assets/8f9182da-5823-4ec3-b806-25e648a24cab" />
</details>

---

### PS

The blog is awesome, it's always entertaining to read, even about API endpoint removal ;) Thank you the Immich team!