### PR TITLE
feat(ui): improve input styling consistency

### DIFF
--- a/apps/ui.immich.app/src/routes/(docs)/components/input/BasicExample.svelte
+++ b/apps/ui.immich.app/src/routes/(docs)/components/input/BasicExample.svelte
@@ -25,8 +25,17 @@
     <Input placeholder="label" />
     <HelperText>Note: this is helper text</HelperText>
   </Field>
-  <Field label="Invalid" invalid>
+  <Field label="Invalid as attribute" invalid>
     <Input placeholder="label" />
     <HelperText color="danger">Must be valid</HelperText>
+  </Field>
+  <Field
+    label="Using browser validation"
+    description="Optionally style the helper text using the peer-[:has(:invalid)] selector."
+  >
+    <Input placeholder="42" type="number" />
+    <HelperText class="invisible text-danger peer-[:has(:invalid)]:visible dark:text-danger">
+      Must be a number.
+    </HelperText>
   </Field>
 </Stack>

--- a/apps/ui.immich.app/src/routes/(docs)/components/input/IconExample.svelte
+++ b/apps/ui.immich.app/src/routes/(docs)/components/input/IconExample.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Input, IconButton, Stack } from '@immich/ui';
+  import { Field, Input, IconButton, Stack } from '@immich/ui';
   import { mdiMagnify } from '@mdi/js';
 </script>
 
@@ -11,9 +11,27 @@
     {/snippet}
   </Input>
   <Input placeholder="Leading icon" leadingIcon={mdiMagnify} />
+  <Field disabled>
+    <Input placeholder="Leading icon" leadingIcon={mdiMagnify} />
+  </Field>
   <Input placeholder="Leading icon button">
     {#snippet leadingIcon()}
       <IconButton icon={mdiMagnify} size="medium" shape="round" variant="ghost" color="secondary" aria-label="Search" />
     {/snippet}
   </Input>
+  <Field disabled>
+    <Input placeholder="Leading icon button">
+      {#snippet leadingIcon(disabled)}
+        <IconButton
+          {disabled}
+          icon={mdiMagnify}
+          size="medium"
+          shape="round"
+          variant="ghost"
+          color="secondary"
+          aria-label="Search"
+        />
+      {/snippet}
+    </Input>
+  </Field>
 </Stack>

--- a/apps/ui.immich.app/src/routes/(docs)/components/time-input/BasicExample.svelte
+++ b/apps/ui.immich.app/src/routes/(docs)/components/time-input/BasicExample.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Field, IconButton, Stack, TimeInput } from '@immich/ui';
+  import { Code, Field, HelperText, IconButton, Stack, TimeInput } from '@immich/ui';
   import { Time } from '@internationalized/date';
   import { mdiClockOutline, mdiClose } from '@mdi/js';
   import type { TimeValue } from 'bits-ui';
@@ -18,7 +18,7 @@
   <Field label="Time">
     <TimeInput bind:value={value1} />
   </Field>
-  <Field label="Leading icon">
+  <Field label="Leading icon" disabled>
     <TimeInput leadingIcon={mdiClockOutline} />
   </Field>
   <Field label="Leading icon button">
@@ -51,5 +51,9 @@
         />
       {/snippet}
     </TimeInput>
+  </Field>
+  <Field label="Validation">
+    <TimeInput maxValue={new Time(0, 0)} />
+    <HelperText class="pt-2">With <Code>maxValue</Code> set to 00:00, all times are invalid.</HelperText>
   </Field>
 </Stack>

--- a/packages/ui/src/lib/components/Input/Input.svelte
+++ b/packages/ui/src/lib/components/Input/Input.svelte
@@ -5,7 +5,7 @@
   import InputIcon from '$lib/internal/InputIcon.svelte';
   import { inputContainerStyles, inputStyles } from '$lib/styles.js';
   import type { InputProps } from '$lib/types.js';
-  import { cleanClass, generateId } from '$lib/utilities/internal.js';
+  import { cleanClass } from '$lib/utilities/internal.js';
   import { tv } from 'tailwind-variants';
 
   let {
@@ -36,13 +36,13 @@
     },
   });
 
-  const id = generateId();
+  const id = $props.id();
   const inputId = `input-${id}`;
   const labelId = `label-${id}`;
   const descriptionId = $derived(description ? `description-${id}` : undefined);
 </script>
 
-<div class="flex w-full flex-col gap-1">
+<div class="flex w-full flex-col gap-1 peer">
   {#if label}
     <Label id={labelId} for={inputId} {label} requiredIndicator={required === 'indicator'} {...labelProps} {size} />
   {/if}
@@ -55,15 +55,15 @@
     bind:this={containerRef}
     class={cleanClass(
       inputContainerStyles({
-        disabled,
         shape,
         roundedSize: shape === 'semi-round' ? size : undefined,
         invalid,
       }),
       className,
     )}
+    data-disabled={disabled ? true : undefined}
   >
-    <InputIcon icon={leadingIcon} {size} />
+    <InputIcon icon={leadingIcon} {size} {disabled} />
 
     <input
       id={inputId}

--- a/packages/ui/src/lib/components/PasswordInput/PasswordInput.svelte
+++ b/packages/ui/src/lib/components/PasswordInput/PasswordInput.svelte
@@ -18,7 +18,7 @@
 </script>
 
 <Input bind:value {size} type={isVisible ? 'text' : 'password'} {color} {...props}>
-  {#snippet trailingIcon()}
+  {#snippet trailingIcon(disabled)}
     {#if value?.length > 0}
       <IconButton
         variant="ghost"
@@ -28,6 +28,7 @@
         class="me-1"
         icon={isVisible ? mdiEyeOffOutline : mdiEyeOutline}
         onclick={() => (isVisible = !isVisible)}
+        {disabled}
         title={labelValue}
         aria-label={labelValue}
       />

--- a/packages/ui/src/lib/components/TimeInput/TimeInput.svelte
+++ b/packages/ui/src/lib/components/TimeInput/TimeInput.svelte
@@ -3,11 +3,10 @@
   import Label from '$lib/components/Label/Label.svelte';
   import InputIcon from '$lib/internal/InputIcon.svelte';
   import { getLocale } from '$lib/state/locale-state.svelte.js';
-  import { inputContainerStyles, inputStyles, styleVariants } from '$lib/styles.js';
+  import { inputContainerStyles, inputSegmentStyles, inputStyles } from '$lib/styles.js';
   import type { TimeInputProps } from '$lib/types.js';
   import { cleanClass } from '$lib/utilities/internal.js';
   import { TimeField, type TimeValue } from 'bits-ui';
-  import { tv } from 'tailwind-variants';
 
   let {
     ref = $bindable(null),
@@ -27,25 +26,6 @@
   const context = getFieldContext();
   const { readOnly, required, invalid, disabled, label, ...labelProps } = $derived(context());
   const size = $derived(initialSize ?? labelProps.size ?? 'small');
-
-  const styles = tv({
-    base: cleanClass(styleVariants.inputContainerCommon, 'flex w-full items-center'),
-    variants: {
-      shape: styleVariants.shape,
-      roundedSize: styleVariants.inputRoundedSize,
-      invalid: {
-        true: 'border-danger/80 border',
-        false: '',
-      },
-    },
-  });
-
-  const segmentStyles = tv({
-    base: 'focus:bg-light-300 focus:text-light-900 data-focused:bg-light-300 data-focused:text-light-900 data-placeholder:text-light-400 dark:focus:bg-light-700 dark:focus:text-light-100 dark:data-focused:bg-light-300 dark:data-focused:text-light-900 rounded px-0.5 py-0.5 tabular-nums outline-none data-disabled:cursor-not-allowed',
-    variants: {
-      textSize: styleVariants.textSize,
-    },
-  });
 </script>
 
 <div bind:this={containerRef} class={cleanClass('flex w-full flex-col gap-1', className)}>
@@ -76,51 +56,43 @@
 
     <TimeField.Input
       bind:ref
-      class={styles({
-        shape,
-        roundedSize: shape === 'semi-round' ? size : undefined,
-        invalid,
-      })}
+      class={cleanClass(
+        inputContainerStyles({
+          shape,
+          roundedSize: shape === 'semi-round' ? size : undefined,
+          invalid,
+        }),
+        className,
+      )}
     >
       {#snippet children({ segments })}
+        <InputIcon icon={leadingIcon} {size} {disabled} />
+
         <div
           class={cleanClass(
-            inputContainerStyles({
-              disabled,
-              shape,
+            inputStyles({
+              textSize: size,
+              leadingPadding: leadingIcon ? 'icon' : 'base',
+              trailingPadding: trailingIcon ? 'icon' : 'base',
               roundedSize: shape === 'semi-round' ? size : undefined,
-              invalid,
             }),
-            className,
+            'font-medium',
           )}
         >
-          <InputIcon icon={leadingIcon} {size} />
-
-          <div
-            class={cleanClass(
-              inputStyles({
-                textSize: size,
-                leadingPadding: leadingIcon ? 'icon' : 'base',
-                trailingPadding: trailingIcon ? 'icon' : 'base',
-                roundedSize: shape === 'semi-round' ? size : undefined,
-              }),
-            )}
-          >
-            {#each segments as { part, value }, i (`segment-${i}`)}
-              {#if part === 'literal'}
-                <TimeField.Segment {part} class="text-muted p-px">
-                  {value}
-                </TimeField.Segment>
-              {:else}
-                <TimeField.Segment {part} class={segmentStyles({ textSize: size })}>
-                  {value}
-                </TimeField.Segment>
-              {/if}
-            {/each}
-          </div>
-
-          <InputIcon icon={trailingIcon} {size} />
+          {#each segments as { part, value }, i (`segment-${i}`)}
+            {#if part === 'literal'}
+              <TimeField.Segment {part} class="text-muted p-px">
+                {value}
+              </TimeField.Segment>
+            {:else}
+              <TimeField.Segment {part} class={inputSegmentStyles({ padding: 'narrow' })}>
+                {value}
+              </TimeField.Segment>
+            {/if}
+          {/each}
         </div>
+
+        <InputIcon icon={trailingIcon} {size} {disabled} />
       {/snippet}
     </TimeField.Input>
   </TimeField.Root>

--- a/packages/ui/src/lib/internal/DatePicker.svelte
+++ b/packages/ui/src/lib/internal/DatePicker.svelte
@@ -6,7 +6,7 @@
   import { zIndex } from '$lib/constants.js';
   import { t } from '$lib/services/translation.svelte.js';
   import { getLocale } from '$lib/state/locale-state.svelte.js';
-  import { styleVariants } from '$lib/styles.js';
+  import { inputContainerStyles, inputSegmentStyles, inputStyles } from '$lib/styles.js';
   import type { Shape, Size } from '$lib/types.js';
   import { cleanClass } from '$lib/utilities/internal.js';
   import type { DateValue } from '@internationalized/date';
@@ -38,27 +38,8 @@
   const { readOnly, required, invalid, disabled, label, ...labelProps } = $derived(context());
   const size = $derived(initialSize ?? labelProps.size ?? 'small');
 
-  const containerStyles = tv({
-    base: cleanClass(styleVariants.inputContainerCommon, 'flex w-full items-center'),
-    variants: {
-      shape: styleVariants.shape,
-      roundedSize: styleVariants.inputRoundedSize,
-      invalid: {
-        true: 'border-danger/80 border',
-        false: '',
-      },
-    },
-  });
-
   const buttonStyles = tv({
     base: 'hover:bg-light-200 hover:dark:bg-light-300 flex h-10 w-10 items-center justify-center rounded-lg hover:cursor-pointer',
-  });
-
-  const segmentStyles = tv({
-    base: 'focus:bg-light-300 focus:text-light-900 data-focused:bg-light-300 data-focused:text-light-900 data-placeholder:text-light-400 dark:focus:bg-light-700 dark:focus:text-light-100 dark:data-focused:bg-light-300 dark:data-focused:text-light-900 rounded px-1 py-0.5 tabular-nums outline-none data-disabled:cursor-not-allowed',
-    variants: {
-      textSize: styleVariants.textSize,
-    },
   });
 </script>
 
@@ -88,16 +69,16 @@
     {/if}
 
     <DatePicker.Input
-      class={containerStyles({
+      class={inputContainerStyles({
         shape,
         roundedSize: shape === 'semi-round' ? size : undefined,
         invalid,
       })}
     >
       {#snippet children({ segments })}
-        <div class={cleanClass(styleVariants.inputCommon, 'w-full px-3 py-2 font-medium')}>
+        <div class={cleanClass(inputStyles({ textSize: size }), 'px-3 py-2 font-medium')}>
           {#each segments as { part, value }, i (`segment-${i}`)}
-            <DatePicker.Segment {part} class={segmentStyles({ textSize: size })}>
+            <DatePicker.Segment {part} class={inputSegmentStyles({ padding: 'wide' })}>
               {value}
             </DatePicker.Segment>
           {/each}
@@ -106,7 +87,7 @@
           {#snippet child({ props })}
             <IconButton
               {...props}
-              class="me-2 shrink-0 rounded-full"
+              class="me-1 shrink-0 rounded-full"
               variant="ghost"
               shape="round"
               color="secondary"

--- a/packages/ui/src/lib/internal/InputIcon.svelte
+++ b/packages/ui/src/lib/internal/InputIcon.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
   import Icon from '$lib/components/Icon/Icon.svelte';
-  import type { IconLike, Size } from '$lib/types.js';
+  import type { IconOrSnippet, Size } from '$lib/types.js';
   import { isIconLike } from '$lib/utilities/internal.js';
-  import type { Snippet } from 'svelte';
   import { tv } from 'tailwind-variants';
 
   type Props = {
-    icon?: IconLike | Snippet;
+    icon?: IconOrSnippet;
     size?: Size;
+    disabled?: boolean;
   };
 
-  const { icon, size }: Props = $props();
+  const { icon, size, disabled }: Props = $props();
 
   const iconStyles = tv({
     base: 'flex shrink-0 items-center justify-center',
@@ -22,16 +22,19 @@
         large: 'w-12',
         giant: 'w-14',
       },
+      disabled: {
+        true: 'pointer-events-none',
+      },
     },
   });
 </script>
 
 {#if icon}
-  <div tabindex="-1" class={iconStyles({ size })}>
+  <div tabindex="-1" class={iconStyles({ size, disabled })}>
     {#if isIconLike(icon)}
       <Icon size="60%" {icon} />
     {:else}
-      {@render icon()}
+      {@render icon(!!disabled)}
     {/if}
   </div>
 {/if}

--- a/packages/ui/src/lib/styles.ts
+++ b/packages/ui/src/lib/styles.ts
@@ -17,10 +17,14 @@ export const styleVariants = {
     muted: 'text-gray-600 dark:text-gray-400',
   },
 
+  inputSegmentCommon:
+    'focus:bg-light-300 focus:text-light-900 dark:focus:bg-light-700 dark:focus:text-light-100 rounded tabular-nums outline-none',
   inputCommon:
-    'disabled:bg-gray-300 disabled:text-dark dark:disabled:bg-gray-900 dark:disabled:text-gray-200 bg-transparent transition outline-none disabled:cursor-not-allowed',
+    'disabled:text-dark dark:disabled:text-gray-200 bg-transparent transition outline-none disabled:cursor-not-allowed',
   inputContainerCommon:
-    'bg-gray-100 ring-1 ring-gray-200 focus-within:ring-primary dark:focus-within:ring-primary transition outline-none focus-within:ring-1 disabled:cursor-not-allowed dark:bg-gray-800 dark:ring-neutral-900',
+    'bg-gray-100 ring-1 ring-gray-200 focus-within:ring-primary dark:focus-within:ring-primary transition outline-none data-disabled:cursor-not-allowed dark:bg-gray-800 dark:ring-neutral-700 data-disabled:bg-light-300 data-disabled:dark:bg-gray-900 has-user-invalid:focus-within:ring-danger has-user-invalid:dark:focus-within:ring-danger has-user-invalid:ring-danger-300 has-user-invalid:dark:ring-danger-300',
+  inputContainerBits:
+    'data-disabled:text-dark data-disabled:dark:text-gray-200 data-invalid:focus-within:ring-danger data-invalid:dark:focus-within:ring-danger data-invalid:ring-danger-300 data-invalid:dark:ring-danger-300',
 
   shape: {
     rectangle: 'rounded-none',
@@ -106,6 +110,16 @@ export const styleVariants = {
   },
 };
 
+export const inputSegmentStyles = tv({
+  base: styleVariants.inputSegmentCommon,
+  variants: {
+    padding: {
+      narrow: 'p-0.5',
+      wide: 'px-1 py-0.5',
+    },
+  },
+});
+
 export const inputStyles = tv({
   base: cleanClass(styleVariants.inputCommon, 'w-full flex-1 py-2.5'),
   variants: {
@@ -129,17 +143,12 @@ export const inputStyles = tv({
 });
 
 export const inputContainerStyles = tv({
-  base: cleanClass(styleVariants.inputContainerCommon, 'flex w-full items-center'),
+  base: cleanClass(styleVariants.inputContainerCommon, styleVariants.inputContainerBits, 'flex w-full items-center'),
   variants: {
     shape: styleVariants.shape,
     roundedSize: styleVariants.inputRoundedSize,
     invalid: {
-      true: 'focus-within:ring-danger dark:focus-within:ring-danger dark:ring-danger-300 ring-danger-300 ring-1',
-      false: '',
-    },
-    disabled: {
-      true: 'bg-light-300 dark:bg-gray-900',
-      false: '',
+      true: 'focus-within:ring-danger dark:focus-within:ring-danger dark:ring-danger-300 ring-danger-300',
     },
   },
 });

--- a/packages/ui/src/lib/types.ts
+++ b/packages/ui/src/lib/types.ts
@@ -177,6 +177,8 @@ export type TableContext = {
   striped?: boolean;
 };
 
+export type IconOrSnippet = IconLike | Snippet<[disabled: boolean]>;
+
 type BaseInputProps<T> = {
   ref?: HTMLInputElement | null;
   class?: string;
@@ -184,8 +186,8 @@ type BaseInputProps<T> = {
   value?: T;
   shape?: Shape;
   inputSize?: HTMLInputAttributes['size'];
-  leadingIcon?: IconLike | Snippet;
-  trailingIcon?: IconLike | Snippet;
+  leadingIcon?: IconOrSnippet;
+  trailingIcon?: IconOrSnippet;
   trailingText?: string;
   containerRef?: HTMLElement | null;
 } & Omit<HTMLInputAttributes, 'size' | 'type' | 'value'>;
@@ -201,8 +203,8 @@ export type TimeInputProps = {
   value?: TimeValue;
   shape?: Shape;
   granularity?: 'hour' | 'minute' | 'second';
-  leadingIcon?: IconLike | Snippet;
-  trailingIcon?: IconLike | Snippet;
+  leadingIcon?: IconOrSnippet;
+  trailingIcon?: IconOrSnippet;
   containerRef?: HTMLElement | null;
   onChange?: (value?: TimeValue) => void;
   minValue?: TimeValue;


### PR DESCRIPTION
Align styles of `Input`, `TimeInput` and the input part of the `DatePicker`, and deduplicate classlists across the three components. Notably:
- Consistent styling of `disabled` components, including leading/trailing buttons
- When the browser (for `Input` with a type or pattern) detects invalid inputs, or when bits-ui does so (and sets `data-invalid`), use that to style the component accordingly. For the normal `input`, using `user-invalid:blabla` pseudoclass selector, in addition to being able to manually force the `invalid` attribute.
  - After focusing and unfocusing a required input, `user-invalid` pseudo-class becomes active (rather than always being invalid, even before interaction).
  - When entering input that doesn't match the type/pattern, like 'asdf' in a `type="number"` input, `user-invalid` also becomes active.
- Consumers could now style `HelperText` depending on the input's pseudo-class by using the `peer-[:has(:invalid)]` selector, e.g. to make helper text red, (in)visible, etc.

There are no functional changes, only styling is somewhat different.