### PR TITLE
awesome: add immich-quickstart tool and a beginner VPS install guide

### DIFF
--- a/apps/awesome.immich.app/src/data/items.json
+++ b/apps/awesome.immich.app/src/data/items.json
@@ -209,6 +209,11 @@
         "title": "Immich Power Tools",
         "description": "A unofficial Immich client to provide better tools to organize and manage your Immich account.",
         "href": "https://github.com/immich-power-tools/immich-power-tools"
+      },
+      {
+        "title": "immich-quickstart",
+        "description": "One command that installs Gemini CLI on a fresh Linux VPS, briefs it with the official Docker Compose install method, and lets the AI agent run the install while you approve each step. Uses only the official compose files and never connects to the Postgres database directly.",
+        "href": "https://github.com/nternet-company/immich-quickstart"
       }
     ]
   },
@@ -293,6 +298,11 @@
         "title": "How-To Install Immich on Rockstor NAS",
         "description": "Set up Immich with External Libraries on your Rockstor NAS server.",
         "href": "https://rockstor.com/docs/interface/docker-based-rock-ons/immich.html"
+      },
+      {
+        "title": "Self-host your photos on a rented VPS, with an AI assistant",
+        "description": "Beginner-friendly walkthrough in English and Dutch: rent a VPS, then either let a free terminal AI run the official install for you or follow the manual Docker Compose steps. Covers hardware sizing, first login, and backups.",
+        "href": "https://fotofoto.app/en/guides/self-host-your-photos-with-immich"
       }
     ]
   }

--- a/apps/awesome.immich.app/src/data/items.json
+++ b/apps/awesome.immich.app/src/data/items.json
@@ -212,7 +212,7 @@
       },
       {
         "title": "immich-quickstart",
-        "description": "One command that installs Gemini CLI on a fresh Linux VPS, briefs it with the official Docker Compose install method, and lets the AI agent run the install while you approve each step. Uses only the official compose files and never connects to the Postgres database directly.",
+        "description": "A single command that sets up Gemini CLI on a fresh VPS and lets it run the official Immich install for you. A manual path is included too.",
         "href": "https://github.com/nternet-company/immich-quickstart"
       }
     ]
@@ -300,8 +300,8 @@
         "href": "https://rockstor.com/docs/interface/docker-based-rock-ons/immich.html"
       },
       {
-        "title": "Self-host your photos on a rented VPS, with an AI assistant",
-        "description": "Beginner-friendly walkthrough in English and Dutch: rent a VPS, then either let a free terminal AI run the official install for you or follow the manual Docker Compose steps. Covers hardware sizing, first login, and backups.",
+        "title": "Self-host your photos on a rented VPS",
+        "description": "A beginner guide, in English and Dutch, to running Immich on a rented VPS, either with an AI assistant or by hand.",
         "href": "https://fotofoto.app/en/guides/self-host-your-photos-with-immich"
       }
     ]


### PR DESCRIPTION
hey! we make foto foto (fotofoto.app), a photo book service. a lot of the people we work with have huge camera rolls, so we've started writing some guides and sharing a few of our favorite tools around photos.

one of those guides is on self-hosting your photos with Immich on a rented VPS, in English and Dutch:
- https://fotofoto.app/en/guides/self-host-your-photos-with-immich
- https://fotofoto.app/nl/gidsen/zelf-je-fotos-hosten-met-immich

while working on it we came across this list and figured the guide might fit under Guides. we also made a small tool along the way, immich-quickstart, one command that sets up Gemini CLI on a fresh VPS and lets it run the official install for you: https://github.com/nternet-company/immich-quickstart