### PR TITLE
feat: add year and month dropdowns for DatePicker

### DIFF
--- a/packages/ui/src/lib/internal/DatePicker.svelte
+++ b/packages/ui/src/lib/internal/DatePicker.svelte
@@ -10,8 +10,8 @@
   import type { Shape, Size } from '$lib/types.js';
   import { cleanClass } from '$lib/utilities/internal.js';
   import type { DateValue } from '@internationalized/date';
-  import { mdiCalendar, mdiChevronLeft, mdiChevronRight } from '@mdi/js';
-  import { DatePicker } from 'bits-ui';
+  import { mdiCalendar, mdiChevronLeft, mdiChevronRight, mdiChevronDown } from '@mdi/js';
+  import { DatePicker, Select } from 'bits-ui';
   import { tv } from 'tailwind-variants';
 
   type Props = {
@@ -41,6 +41,14 @@
   const buttonStyles = tv({
     base: 'hover:bg-light-200 hover:dark:bg-light-300 flex h-10 w-10 items-center justify-center rounded-lg hover:cursor-pointer',
   });
+  const generateYearRange = () => {
+    const currentYear = new Date().getFullYear();
+    const years: number[] = [];
+    for (let y = currentYear+1; y >= 1950; y--) {
+      years.push(y);
+    }
+    return years;
+  };
 </script>
 
 <div class={cleanClass('flex w-full flex-col gap-1', className)}>
@@ -111,7 +119,65 @@
               <DatePicker.PrevButton class={buttonStyles()}>
                 <Icon icon={mdiChevronLeft} size="1.25rem" />
               </DatePicker.PrevButton>
-              <DatePicker.Heading class="text-sm font-semibold" />
+              {@const current = months[0].value}
+              <div class="flex items-center gap-1 text-sm font-semibold">
+                  <Select.Root
+                    type="single"
+                    value={current.month.toString()}
+                    onValueChange={(val) => {
+                      date = current.set({ month: Number(val) });
+                    }}
+                  >
+                    <Select.Trigger class="focus-visible:ring-2 flex items-center gap-1 bg-transparent border-none font-semibold cursor-pointer outline-none rounded-lg px-1 text-inherit hover:bg-light-200 dark:hover:bg-light-300">
+                      <span>{new Intl.DateTimeFormat(getLocale(), { month: 'long' }).format(new Date(2000, current.month - 1))}</span>
+                      <Icon icon={mdiChevronDown} size="1.25rem" />
+                    </Select.Trigger>
+
+                    <Select.Content class="bg-subtle border p-2 shadow-lg rounded-xl z-50">
+                      <Select.Group>
+                        {#each Array.from({ length: 12 }, (_, i) => i + 1) as month (month)}
+                          <Select.Item
+                            value={month.toString()}
+                            label={new Intl.DateTimeFormat(getLocale(), { month: 'long' }).format(new Date(2000, month - 1))}
+                            class="px-2 py-1 hover:bg-light-200 dark:hover:bg-light-300 cursor-pointer rounded-md data-highlighted:bg-light-300 outline-none text-sm font-medium"
+                          >
+                            {new Intl.DateTimeFormat(getLocale(), { month: 'long' }).format(new Date(2000, month - 1))}
+                          </Select.Item>
+                        {/each}
+                      </Select.Group>
+                    </Select.Content>
+                  </Select.Root>
+                <Select.Root
+                  type="single"
+                  value={current.year.toString()}
+                  onValueChange={(val) => {
+                    date = current.set({ year: Number(val) });
+                  }}
+                >
+                  <Select.Trigger class="focus-visible:ring-2 flex items-center gap-1 bg-transparent border-none font-semibold cursor-pointer outline-none rounded-lg px-1 text-inherit hover:bg-light-200 dark:hover:bg-light-300">
+                    <span>{current.year}</span>
+                    <Icon icon={mdiChevronDown} size="1.25rem" />
+                  </Select.Trigger>
+
+                  <Select.Content class="bg-subtle border p-2 shadow-lg rounded-xl z-50">
+                    <Select.Viewport class="max-h-60 overflow-y-auto p-2">
+                      <Select.Group>
+                        {#each generateYearRange() as year (year)}
+                          <Select.Item
+                            value={year.toString()}
+                            label={year.toString()}
+                            class="px-2 py-1 hover:bg-light-200 dark:hover:bg-light-300 cursor-pointer rounded-md data-highlighted:bg-light-300 outline-none text-sm font-medium"
+                          >
+                            {year}
+                          </Select.Item>
+                        {/each}
+                      </Select.Group>
+                    </Select.Viewport>
+                  </Select.Content>
+                </Select.Root>
+
+              </div>
+
               <DatePicker.NextButton class={buttonStyles()}>
                 <Icon icon={mdiChevronRight} size="1.25rem" />
               </DatePicker.NextButton>


### PR DESCRIPTION
# Overview
When using the date search feature, the calendar only allows navigating month by month and there's no way to quickly jump to a specific year. So in order to streamline the navigation process, we included a month and year dropdown that would enable users to jump quickly to the desired date.
This issue was discussed in https://github.com/immich-app/immich/discussions/29652
 
# UI
<img width="906" height="738" alt="image" src="https://github.com/user-attachments/assets/b9bde28d-393c-43a1-9fa7-4ad5ec6f40ea" />
<img width="856" height="702" alt="image" src="https://github.com/user-attachments/assets/e0fe3585-7498-4672-965a-251b2e066f73" />


# Testing
* Normal workflow: selecting a month and year jumps the calendar correctly
* Earliest year in range (1950): calendar navigates correctly
* Latest year in dropdown (current year + 1): calendar navigates correctly
* Arrow buttons after dropdown selection: continue to work correctly
* Months with fewer than 31 days: day grid updates correctly
* Keyboard navigation: Works using arrows and tabs

# Limitations
* Keeps navigating past currentYear + 1 using monthly navigation, but could be useful in cases where people need later years
* Year ranges from 1950 to currentYear + 1 to have a contained range that wouldn't go on forever (+ 1 is meant to fix any sort of time zone conflict)
* 1950 felt like reasonable year to start at but we are open to have the dropdown range further

# Collaborators
Thank you @Fardeen0-0 @swell-d0t :)