### PR TITLE
fix(ui): enforce LTR direction for PIN inputs

### DIFF
--- a/packages/ui/src/lib/components/PinInput/PinInput.svelte
+++ b/packages/ui/src/lib/components/PinInput/PinInput.svelte
@@ -73,7 +73,7 @@
     aria-labelledby={label && labelId}
     {disabled}
     aria-disabled={disabled}
-    class="group flex w-fit items-center gap-2"
+    class="group flex w-fit items-center gap-2 [direction:ltr]"
     maxlength={length}
     pattern={REGEXP_ONLY_DIGITS}
     type={password ? 'password' : 'text'}


### PR DESCRIPTION
## Description

Force `PinInput` to use LTR direction by default.

OTP/PIN codes are numeric and should always be entered and displayed left-to-right, regardless of the application's text direction. This ensures consistent digit ordering and behavior in RTL layouts.