### PR TITLE
fix(sql-tools)!: separate runtime and source migration folders

### DIFF
--- a/packages/sql-tools/src/bin/cli.ts
+++ b/packages/sql-tools/src/bin/cli.ts
@@ -25,7 +25,11 @@ const program = new Command('sql-tools');
 
 program
   .requiredOption('-u, --url <url>', 'Database connection url')
-  .option('-f, --folder <migrationsFolder>', 'Path to the runnable (compiled) migration files', 'dist/schema/migrations')
+  .option(
+    '-f, --folder <migrationsFolder>',
+    'Path to the runnable (compiled) migration files',
+    'dist/schema/migrations',
+  )
   .option('--source-folder <migrationsSourceFolder>', 'Path to the migration source files', 'src/schema/migrations');
 
 program

--- a/packages/sql-tools/src/bin/cli.ts
+++ b/packages/sql-tools/src/bin/cli.ts
@@ -25,7 +25,8 @@ const program = new Command('sql-tools');
 
 program
   .requiredOption('-u, --url <url>', 'Database connection url')
-  .option('-f, --folder <migrationsFolder>', 'Path to the migration files', 'dist/schema/migrations');
+  .option('-f, --folder <migrationsFolder>', 'Path to the runnable (compiled) migration files', 'dist/schema/migrations')
+  .option('--source-folder <migrationsSourceFolder>', 'Path to the migration source files', 'src/schema/migrations');
 
 program
   .command('query')
@@ -48,12 +49,7 @@ migrations
 migrations
   .command('revert')
   .description('Revert the most recent migration')
-  .requiredOption(
-    '-f, --folder <migrationsFolder>',
-    'Path to the folder the migration files are in',
-    'src/schema/migrations',
-  )
-  .action(withMigrator((migrator, { folder }) => migrator.revert(join(process.cwd(), folder))));
+  .action(withMigrator((migrator, { sourceFolder }) => migrator.revert(join(process.cwd(), sourceFolder))));
 
 migrations
   .command('create')

--- a/packages/sql-tools/src/migration.ts
+++ b/packages/sql-tools/src/migration.ts
@@ -129,14 +129,14 @@ export class Migrator {
     return reverted.migrationName;
   }
 
-  async revert(migrationsDistFolder: string) {
+  async revert(sourceFolder: string) {
     const migrationName = await this.#revertLastMigration();
     if (!migrationName) {
       console.log('No migrations to revert');
       return;
     }
 
-    this.#markMigrationAsReverted(migrationName, migrationsDistFolder);
+    this.#markMigrationAsReverted(migrationName, sourceFolder);
   }
 
   async generate({ dist, targetPath, withComments }: { dist: string; targetPath: string; withComments: boolean }) {
@@ -217,9 +217,9 @@ ${downSql}
 `;
   }
 
-  #markMigrationAsReverted(migrationName: string, migrationsDistFolder: string) {
-    const sourcePath = join(this.#migrationsFolder, `${migrationName}.ts`);
-    const revertedFolder = join(this.#migrationsFolder, 'reverted');
+  #markMigrationAsReverted(migrationName: string, sourceFolder: string) {
+    const sourcePath = join(sourceFolder, `${migrationName}.ts`);
+    const revertedFolder = join(sourceFolder, 'reverted');
     const revertedPath = join(revertedFolder, `${migrationName}.ts`);
 
     if (existsSync(revertedPath)) {
@@ -232,7 +232,7 @@ ${downSql}
       console.warn(`Source migration file not found for ${migrationName}`);
     }
 
-    const distBase = join(migrationsDistFolder, migrationName);
+    const distBase = join(this.#migrationsFolder, migrationName);
     for (const extension of ['.js', '.js.map', '.d.ts']) {
       const filePath = `${distBase}${extension}`;
       if (existsSync(filePath)) {


### PR DESCRIPTION
The global `-f` conflated the folder Kysely loads compiled migrations from with the folder migration sources live in. `revert` papered over this with a command-level `-f` redeclare that commander shadows — which accidentally kept revert working (Kysely must load from dist) while silently breaking its source-file move.

This splits the concepts: `-f/--folder` = runnable folder (unchanged default), new global `--source-folder` = sources (default `src/schema/migrations`). `revert` now uses both, so reverted migrations actually get moved to `reverted/` again.