### PR TITLE
feat: add Rollfilm

### DIFF
--- a/apps/awesome.immich.app/src/data/items.json
+++ b/apps/awesome.immich.app/src/data/items.json
@@ -190,6 +190,11 @@
         "title": "Lightroom Immich Plugin: lrc-immich-plugin",
         "description": "Lightroom plugin to publish, export photos from Lightroom to Immich. Import from Immich to Lightroom is also supported.",
         "href": "https://blog.fokuspunk.de/lrc-immich-plugin/"
+      },
+      {
+        "title": "Rollfilm",
+        "description": "Desktop photo manager for macOS, Windows and Linux. Import from a memory card, cull, rate and edit RAW files, then mirror photos and albums to Immich in the background. Semantic search runs locally.",
+        "href": "https://github.com/pasqualkreher/rollfilm"
       }
     ]
   },


### PR DESCRIPTION
Adds [Rollfilm](https://github.com/pasqualkreher/rollfilm) under **Integrations**.

Rollfilm is a local-first desktop photo manager (macOS, Windows, Linux). It covers the part of the workflow that happens before a photo reaches a server — importing from a memory card, culling, rating, RAW development — and then mirrors photos and albums to an existing Immich server. Sync runs as a background reconciliation loop with three modes (manual, selective, full), matches assets by checksum so Immich deduplicates correctly, and mirrors album membership and deletions.

Against the criteria in the README:

- **Open source** — MIT.
- **Non-commercial** — a spare-time hobby project, nothing paid, nothing planned.
- **Link goes to the source code** — points at the GitHub repository.
- **No direct Postgres access** — everything goes through the Immich REST API with a user-supplied server URL and API key, entered in the app. Nothing touches the database.

Happy to reword the description or move it to a different category if Integrations is not the right fit.