### PR TITLE
fix(sql-tools): force ISO DateStyle on postgres connections

### DIFF
--- a/packages/sql-tools/src/connections/postgres-connection.ts
+++ b/packages/sql-tools/src/connections/postgres-connection.ts
@@ -38,6 +38,7 @@ export const createPostgres = (options: DatabasePostgresOptions = {}) => {
     connection = { connectionType: 'url', url: 'postgres://postgres:postgres@localhost:5432/postgres' },
     maxConnections = 10,
     timeZone = 'UTC',
+    dateStyle = 'ISO',
     convertToJsDate = true,
     convertBigIntToNumber = true,
     onNotice,
@@ -76,6 +77,7 @@ export const createPostgres = (options: DatabasePostgresOptions = {}) => {
     max: maxConnections,
     connection: {
       TimeZone: timeZone,
+      DateStyle: dateStyle,
     },
     types,
     onnotice: onNotice,

--- a/packages/sql-tools/src/types.ts
+++ b/packages/sql-tools/src/types.ts
@@ -10,6 +10,7 @@ export type DatabasePostgresOptions = {
   connection?: DatabaseConnectionParams;
   maxConnections?: number;
   timeZone?: string;
+  dateStyle?: string;
   convertToJsDate?: boolean;
   convertBigIntToNumber?: boolean;
   onNotice?: (notice: Notice) => void;


### PR DESCRIPTION
postgres renders timestamps using the session datestyle. we already force TimeZone UTC on the connection but not DateStyle, so a database configured with a non ISO datestyle (postgresql.conf or alter database/role, survives backups) returns dates like `18.08.2026 00:00:00 UTC`. new Date() in the parser cant read that and every date field becomes null after stringify, nullable fields silently lose data and required ones crash the mobile sync stream. came out of immich-app/immich#30755 debugging.

verified against a db with `alter database ... set datestyle to 'German'`: without this every date on the sync wire is null, with DateStyle ISO in the startup packet the session overrides the db setting and values come back correct.
