### PR TITLE
feat: add Immich Compressor

### DIFF
--- a/apps/awesome.immich.app/src/data/items.json
+++ b/apps/awesome.immich.app/src/data/items.json
@@ -238,6 +238,11 @@
         "title": "Immich Dark Theme Generator",
         "description": "Generate a custom dark theme for Immich.",
         "href": "https://github.com/damongolding/immich-theme-generator"
+      },
+      {
+        "title": "Immich Compressor",
+        "description": "Recompress both new uploads and the originals already in your library to HEVC and JPEG, via a workflow webhook or a backfill scan, verifying each replacement before any original is removed.",
+        "href": "https://github.com/Navilois/immich-compressor"
       }
     ]
   },


### PR DESCRIPTION
Adds `immich-compressor` to the **Tools** list.

It is a self-hosted service, and it works on both new uploads and assets that are already in
the library. An Immich workflow webhook picks up new uploads as they arrive; a `backfill`
command walks an existing library, inventories what is worth re-encoding and queues it,
largest first. Either way it downloads the original, re-encodes it (HEVC video, JPEG stills),
verifies the replacement against the live server, carries album membership, tags, rating,
description, GPS and timeline position across, and only optionally removes the original
afterwards. Requires Immich v3.0.0+ for workflows; developed and verified against v3.1.0.

Against the criteria in `apps/awesome.immich.app/README.md`:

- **Open source** — MIT.
- **Non-commercial** — no paid tier, no telemetry, no phone-home.
- **Link goes to the source/README** — yes.
- **No direct Postgres access** — it talks to the public REST API only, and never touches
  `UPLOAD_LOCATION`. Nothing to disclose.

It complements Immich Upload Optimizer rather than overlapping with it: that one optimises
files on their way in, this one works on assets that are already stored.

Ships with `dry_run: true` and `trash_original: false`, so a default install changes nothing
on the server.