### PR TITLE
fix: prevent logo from being draggable

### DIFF
--- a/packages/ui/src/lib/components/Logo/Logo.svelte
+++ b/packages/ui/src/lib/components/Logo/Logo.svelte
@@ -37,4 +37,4 @@
   const src = $derived(logoManager.getLogo(variant, themeManager.value));
 </script>
 
-<img {src} class={cleanClass(styles({ size, variant }), className)} alt="Immich logo" />
+<img {src} class={cleanClass(styles({ size, variant }), className)} alt="Immich logo" draggable="false" />


### PR DESCRIPTION
Makes the Logo non-draggable.
Follow-up to feedback on [immich#30454](https://github.com/immich-app/immich/pull/30454#discussion_r3748911328) 

Closes [#30289](https://github.com/immich-app/immich/issues/30289)