### PR TITLE
fix(ui): position the toast panel at the inline end so RTL layouts don't cover the back button

### DIFF
--- a/packages/ui/src/lib/components/Toast/ToastPanel.svelte
+++ b/packages/ui/src/lib/components/Toast/ToastPanel.svelte
@@ -14,7 +14,7 @@
 <TooltipProvider>
   <div
     class={cleanClass(
-      isEmpty ? 'hidden' : 'absolute top-0 right-0 flex flex-col items-end justify-end gap-2 p-4',
+      isEmpty ? 'hidden' : 'absolute top-0 end-0 flex flex-col items-end justify-end gap-2 p-4',
       zIndex.ToastPanel,
       className,
     )}


### PR DESCRIPTION
## What

`ToastPanel` pinned itself with the physical `right-0`, so under RTL the toast stack stayed on the physical right — directly on top of the back button in the top-start corner. Swapping to the logical `end-0` mirrors it with the writing direction.

```diff
-      isEmpty ? 'hidden' : 'absolute top-0 right-0 flex flex-col items-end justify-end gap-2 p-4',
+      isEmpty ? 'hidden' : 'absolute top-0 end-0 flex flex-col items-end justify-end gap-2 p-4',
```

In LTR, Tailwind compiles `end-0` to `right: 0`, so the rendered CSS there is identical to before — this is a no-op for LTR consumers.

## Why this repo

The bug was reported against the immich web app in immich-app/immich#31015, but `ToastPanel` lives in `@immich/ui`, so the fix belongs here. Merging this alone won't close that issue — it needs an `@immich/ui` release and a version bump in `immich-app/immich`. Happy to open the bump PR once this ships.

Related to immich-app/immich#31015

## Screenshots

Reproduced against the `@immich/ui` dev server (`pnpm --filter @immich/ui start:dev`) with the document direction set to `rtl`.

| | |
|---|---|
| **RTL, before** | _(attached below)_ |
| **RTL, after** | _(attached below)_ |
| **LTR, after** | _(attached below)_ |

## Checks run

From the repo root, on macOS:

- `pnpm format` — "All matched files use Prettier code style!"
- `npx eslint --max-warnings 0 packages/ui/src/lib/components/Toast/ToastPanel.svelte` — clean (the repo-wide `pnpm lint` runs out of V8 heap on my machine, so I scoped it to the changed file)
- `pnpm --filter @immich/ui check` — 973 files, 0 errors, 4 warnings, all pre-existing `state_referenced_locally` warnings in `Child.svelte`, `Alert.svelte`, and `CommandPaletteModal.svelte`, none touched by this change
