### PR TITLE
feat: add Media Backup Manager

### DIFF
--- a/apps/awesome.immich.app/src/data/items.json
+++ b/apps/awesome.immich.app/src/data/items.json
@@ -2,7 +2,10 @@
   {
     "name": "Client apps",
     "id": "client-apps",
-    "types": ["client", "clients"],
+    "types": [
+      "client",
+      "clients"
+    ],
     "projects": [
       {
         "title": "ImmichFrame",
@@ -80,7 +83,11 @@
   {
     "id": "cli-tools",
     "name": "Command-line tools",
-    "types": ["cli", "command-line", "command-line-interface"],
+    "types": [
+      "cli",
+      "command-line",
+      "command-line-interface"
+    ],
     "projects": [
       {
         "title": "immich-go",
@@ -172,7 +179,10 @@
   {
     "id": "integrations",
     "name": "Integrations",
-    "types": ["integration", "integrations"],
+    "types": [
+      "integration",
+      "integrations"
+    ],
     "projects": [
       {
         "title": "Immich Kodi",
@@ -196,7 +206,10 @@
   {
     "id": "tools",
     "name": "Tools",
-    "types": ["tool", "tools"],
+    "types": [
+      "tool",
+      "tools"
+    ],
     "projects": [
       {
         "title": "Immich-Tiktok-Remover",
@@ -238,13 +251,21 @@
         "title": "Immich Dark Theme Generator",
         "description": "Generate a custom dark theme for Immich.",
         "href": "https://github.com/damongolding/immich-theme-generator"
+      },
+      {
+        "title": "Media Backup Manager",
+        "description": "Windows desktop app for downloading original photos and videos from Immich by album or year for local backups. Uses only the Immich API without direct database access.",
+        "href": "https://github.com/olmos-cmd/Media-Backup-Manager-for-immich"
       }
     ]
   },
   {
     "id": "distributions",
     "name": "Distributions",
-    "types": ["distribution", "distributions"],
+    "types": [
+      "distribution",
+      "distributions"
+    ],
     "projects": [
       {
         "title": "Immich Distribution",
@@ -261,7 +282,10 @@
   {
     "id": "guides",
     "name": "Guides",
-    "types": ["guide", "guides"],
+    "types": [
+      "guide",
+      "guides"
+    ],
     "projects": [
       {
         "title": "Cloudflare Tunnels with SSO/OAuth",

--- a/apps/awesome.immich.app/src/data/items.json
+++ b/apps/awesome.immich.app/src/data/items.json
@@ -2,10 +2,7 @@
   {
     "name": "Client apps",
     "id": "client-apps",
-    "types": [
-      "client",
-      "clients"
-    ],
+    "types": ["client", "clients"],
     "projects": [
       {
         "title": "ImmichFrame",
@@ -83,11 +80,7 @@
   {
     "id": "cli-tools",
     "name": "Command-line tools",
-    "types": [
-      "cli",
-      "command-line",
-      "command-line-interface"
-    ],
+    "types": ["cli", "command-line", "command-line-interface"],
     "projects": [
       {
         "title": "immich-go",
@@ -179,10 +172,7 @@
   {
     "id": "integrations",
     "name": "Integrations",
-    "types": [
-      "integration",
-      "integrations"
-    ],
+    "types": ["integration", "integrations"],
     "projects": [
       {
         "title": "Immich Kodi",
@@ -206,10 +196,7 @@
   {
     "id": "tools",
     "name": "Tools",
-    "types": [
-      "tool",
-      "tools"
-    ],
+    "types": ["tool", "tools"],
     "projects": [
       {
         "title": "Immich-Tiktok-Remover",
@@ -262,10 +249,7 @@
   {
     "id": "distributions",
     "name": "Distributions",
-    "types": [
-      "distribution",
-      "distributions"
-    ],
+    "types": ["distribution", "distributions"],
     "projects": [
       {
         "title": "Immich Distribution",
@@ -282,10 +266,7 @@
   {
     "id": "guides",
     "name": "Guides",
-    "types": [
-      "guide",
-      "guides"
-    ],
+    "types": ["guide", "guides"],
     "projects": [
       {
         "title": "Cloudflare Tunnels with SSO/OAuth",


### PR DESCRIPTION
Adds Media Backup Manager to the Tools section.

Media Backup Manager is a non-commercial, open-source Windows desktop application licensed under GPL-3.0-only. It downloads original photos and videos from Immich by album or year for local backups.

The application communicates exclusively through the Immich API. It does not connect directly to or modify the Immich PostgreSQL database.

Source code:
https://github.com/olmos-cmd/Media-Backup-Manager-for-immich