### PR TITLE
Add immich-auto-dumper to awesome-immich Tools

### DIFF
--- a/apps/awesome.immich.app/src/data/items.json
+++ b/apps/awesome.immich.app/src/data/items.json
@@ -275,6 +275,13 @@
         "title": "immich-edit",
         "description": "Self-hosted, non-destructive RAW editor that uses Immich as its photo library while keeping originals unchanged.",
         "sourceCodeUrl": "https://github.com/haavardnk/immich-edit"
+      },
+      {
+        "title": "immich-auto-dumper",
+        "description": "Automatically archives your oldest photos and videos to external storage (NAS, rclone, spare disk) when the library grows past a size limit, while Immich keeps showing them exactly as before via an external library. Connects directly to Immich's Postgres database (read and write) to update asset paths.",
+        "websiteUrl": "https://github.com/de-seingalt/immich-auto-dumper#readme",
+        "sourceCodeUrl": "https://github.com/de-seingalt/immich-auto-dumper",
+        "tags": ["Vibe-Coded"]
       }
     ]
   },


### PR DESCRIPTION
## Summary
- Adds [immich-auto-dumper](https://github.com/de-seingalt/immich-auto-dumper) to the "Tools" category of awesome.immich.app.
- Automatically archives the oldest photos and videos to external storage (NAS, rclone remote, spare disk) once the Immich library grows past a configured size, while Immich keeps serving them exactly as before through an external library.

## Disclosure: direct Postgres access
The tool connects directly to Immich's Postgres database via `psql` in the DB container: it `SELECT`s from `asset`/`asset_exif`/`library`/`user` to find candidates and validate the schema, and runs an `UPDATE` on `asset` to relocate `originalPath` and set `isExternal`/`isOffline` once a file is copied and verified. Called out here and in the entry description per the contribution guidelines.

## Note
Tagged `Vibe-Coded`: predominantly AI-assisted, with careful human review of every change and testing across real deployments on a VM with several Immich installations.

## Checklist
- [x] Open source (MIT license)
- [x] Non-commercial
- [x] `sourceCodeUrl` points at the source, `websiteUrl` at the README
- [ ] ~~Does not connect directly to Immich's Postgres database~~ — it does; disclosed above
